### PR TITLE
fix(todo): 테스트 코드 수정 및 자바 테스트를 위해 `build.gradle`에 sourceSets 설정

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -73,6 +73,13 @@ allOpen {
     annotation("jakarta.persistence.MappedSuperclass")
 }
 
+sourceSets {
+    test {
+        java.srcDirs += ["src/test/java"]
+        kotlin.srcDirs += ["src/test/kotlin"]
+    }
+}
+
 // QueryDSL
 kapt {
     keepJavacAnnotationProcessors = true

--- a/src/test/java/org/example/expert/domain/todo/controller/TodoControllerTest.java
+++ b/src/test/java/org/example/expert/domain/todo/controller/TodoControllerTest.java
@@ -1,5 +1,11 @@
 package org.example.expert.domain.todo.controller;
 
+import static org.mockito.Mockito.when;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+import java.time.LocalDateTime;
 import org.example.expert.domain.common.dto.AuthUser;
 import org.example.expert.domain.common.exception.InvalidRequestException;
 import org.example.expert.domain.todo.dto.response.TodoResponse;
@@ -13,13 +19,6 @@ import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
 import org.springframework.boot.test.mock.mockito.MockBean;
 import org.springframework.http.HttpStatus;
 import org.springframework.test.web.servlet.MockMvc;
-
-import java.time.LocalDateTime;
-
-import static org.mockito.Mockito.when;
-import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
-import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
-import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
 @WebMvcTest(TodoController.class)
 class TodoControllerTest {
@@ -35,17 +34,17 @@ class TodoControllerTest {
         // given
         long todoId = 1L;
         String title = "title";
-        AuthUser authUser = new AuthUser(1L, "email", UserRole.USER);
+        AuthUser authUser = new AuthUser(1L, "email", "nickname", UserRole.USER);
         User user = User.fromAuthUser(authUser);
         UserResponse userResponse = new UserResponse(user.getId(), user.getEmail());
         TodoResponse response = new TodoResponse(
-                todoId,
-                title,
-                "contents",
-                "Sunny",
-                userResponse,
-                LocalDateTime.now(),
-                LocalDateTime.now()
+            todoId,
+            title,
+            "contents",
+            "Sunny",
+            userResponse,
+            LocalDateTime.now(),
+            LocalDateTime.now()
         );
 
         // when
@@ -53,9 +52,9 @@ class TodoControllerTest {
 
         // then
         mockMvc.perform(get("/todos/{todoId}", todoId))
-                .andExpect(status().isOk())
-                .andExpect(jsonPath("$.id").value(todoId))
-                .andExpect(jsonPath("$.title").value(title));
+            .andExpect(status().isOk())
+            .andExpect(jsonPath("$.id").value(todoId))
+            .andExpect(jsonPath("$.title").value(title));
     }
 
     @Test
@@ -65,13 +64,13 @@ class TodoControllerTest {
 
         // when
         when(todoService.getTodo(todoId))
-                .thenThrow(new InvalidRequestException("Todo not found"));
+            .thenThrow(new InvalidRequestException("Todo not found"));
 
         // then
         mockMvc.perform(get("/todos/{todoId}", todoId))
-                .andExpect(status().isOk())
-                .andExpect(jsonPath("$.status").value(HttpStatus.OK.name()))
-                .andExpect(jsonPath("$.code").value(HttpStatus.OK.value()))
-                .andExpect(jsonPath("$.message").value("Todo not found"));
+            .andExpect(status().isBadRequest())
+            .andExpect(jsonPath("$.status").value(HttpStatus.BAD_REQUEST.name()))
+            .andExpect(jsonPath("$.code").value(HttpStatus.BAD_REQUEST.value()))
+            .andExpect(jsonPath("$.message").value("Todo not found"));
     }
 }


### PR DESCRIPTION
- closed #7 

### sourceSets 설정 이유

- id "org.jetbrains.kotlin.jvm", kapt 같은 플러그인을 적용하면 Gradle이 src/test/kotlin을 기본 테스트 소스 디렉토리로 우선 잡음
- src/test/java도 포함시켜줘야 하는데, 안 하면 Java 테스트는 빌드 대상에서 빠지거나, 정상 빌드가 안 됨
- 그래서 변경해도 반영이 안 됨