### PR TITLE
refactor(todo): QueryDSL 검색 쿼리 최적화

### DIFF
--- a/src/main/java/org/example/expert/domain/todo/controller/TodoController.java
+++ b/src/main/java/org/example/expert/domain/todo/controller/TodoController.java
@@ -50,7 +50,7 @@ public class TodoController {
     }
 
     @GetMapping("/todos/search")
-    public ResponseEntity<Page<TodoSearchResponse>> searchTitleAndCount(
+    public ResponseEntity<Page<TodoSearchResponse>> searchWithRelationCounts(
         @RequestParam(required = false) String keyword,
         @RequestParam(required = false) LocalDate startDate,
         @RequestParam(required = false) LocalDate endDate,
@@ -59,6 +59,7 @@ public class TodoController {
         @RequestParam(defaultValue = "10") int size
     ) {
         return ResponseEntity.ok(
-            todoService.searchTitleAndCount(keyword, startDate, endDate, managerName, page, size));
+            todoService.searchWithRelationCounts(keyword, startDate, endDate, managerName, page,
+                size));
     }
 }

--- a/src/main/java/org/example/expert/domain/todo/repository/TodoRepositoryCustom.java
+++ b/src/main/java/org/example/expert/domain/todo/repository/TodoRepositoryCustom.java
@@ -11,7 +11,7 @@ public interface TodoRepositoryCustom {
 
     Optional<Todo> findByIdWithUser(Long todoId);
 
-    Page<TodoSearchResponse> searchTitleAndCount(
+    Page<TodoSearchResponse> searchWithRelationCounts(
         String keyword,
         LocalDate startDate,
         LocalDate endDate,

--- a/src/main/java/org/example/expert/domain/todo/service/TodoService.java
+++ b/src/main/java/org/example/expert/domain/todo/service/TodoService.java
@@ -89,7 +89,7 @@ public class TodoService {
         );
     }
 
-    public Page<TodoSearchResponse> searchTitleAndCount(
+    public Page<TodoSearchResponse> searchWithRelationCounts(
         String keyword,
         LocalDate startDate,
         LocalDate endDate,
@@ -100,7 +100,7 @@ public class TodoService {
 
         Pageable pageable = PageRequest.of(page - 1, size);
 
-        return todoRepository.searchTitleAndCount(keyword, startDate,
+        return todoRepository.searchWithRelationCounts(keyword, startDate,
             endDate, managerName, pageable);
     }
 }

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -11,6 +11,7 @@ spring:
       hibernate:
         show_sql: true
         format_sql: true
+    open-in-view: false
 
 jwt:
   secret:


### PR DESCRIPTION
- related to #15 

1. `content` 조회와 `total` 조회 조건 중복되어 `BooleanBuilder` 사용하여 중복 방지

2. SubQuery를 사용해 매니저/댓글 수 조회하는 방식에서 `join` + `group by` 로 변경해 쿼리 최적화
   - 서브쿼리 사용시 todo 수 만큼 반복 실행되는 문제 **(유사 N+1)**
   - 조인 사용 시 한번에 묶어 집계 처리 가능
   - 조인 사용 시 서브쿼리보다 성능이 좋음

3. `PageImpl` 반환 대신 `PageableExecutionUtils.getPage()` 를 사용
   - **count 쿼리 최적화 가능**
   - **조건1**: 첫 페이지에서 가져온 `content` 크기가 `pageable.getPageSize()`보다 작으면 `count` 쿼리 실행 안 함
   - **조건2**: 마지막 페이지에서 가져온 `content` 크기가 `pageable.getPageSize()`보다 작으면 역시 `count` 쿼리 실행 안 함

4. `countDistinct()`를 사용하여 중복 집계 방지

5. `LocalTime.MAX` 는 DB 타입에 따라 처리 방식이 다르므로, `plusDays(1).atStartOfDay().minusNanos(1)`를 사용하여 명확하게 처리

6. 쿼리 메서드명을 더욱 의도가 드러나는 명칭으로 변경