### PR TITLE
fix(docker): 이미지 빌드 실패로 `Dockerfile` 수정

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,8 +1,19 @@
 # 빌드 스테이지
 FROM gradle:8.14-jdk17 AS builder
 WORKDIR /app
+
+# 캐시를 위해 wrapper 먼저 복사
+COPY gradlew ./
+COPY gradle/wrapper/ ./gradle/wrapper/
+
+# 나머지 소스 복사
 COPY . .
-RUN ./gradlew clean build -x test
+
+# 윈도우 줄바꿈 제거 + 실행 권한 부여
+RUN sed -i 's/\r$//' gradlew && chmod +x gradlew
+
+# --no-daemon 권장
+RUN ./gradlew clean build -x test --no-daemon
 
 # 실행 스테이지
 FROM amazoncorretto:17


### PR DESCRIPTION
- related to #17 
- Windows에서 작업한 gradlew가 CRLF 줄바꿈(\r\n) 이라 컨테이너의 /bin/sh가 실행 파일을 인식하지 못함