### PR TITLE
fix(workflow): `ci.yml` 파일의 `concurrency group` 수정

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -12,7 +12,7 @@ on:
       - main
 
 concurrency:
-  group: ci-${{ github.event.pull_request.head.repo.full_name || github.repository }}-${{ github.event.pull_request.head.ref || github.ref_name }}
+  group: ci-${{ github.ref }}
   cancel-in-progress: true
 
 jobs:


### PR DESCRIPTION
`feat/*` 브랜치 커밋과 `dev pr`의 워크플로우 중복을 방지하기 위해 처리하였지만,
`cancel-in-progress: true`로 인해 처음 돌아가던 워크플로우가 실패 처리 되며
목록에서 ❌로 표시되는 현상때문에 롤백