### PR TITLE
fix(config): CI에서 `-x test` 가 붙는 현상 해결을 위한 테스트 커밋

### DIFF
--- a/.github/workflows/reusable-build.yml
+++ b/.github/workflows/reusable-build.yml
@@ -26,5 +26,10 @@ jobs:
       - name: Grant execute permission for Gradlew
         run: chmod +x ./gradlew
 
-      - name: Build ${{ inputs.run-tests && '(with tests)' || '(skip tests)' }}
-        run: ./gradlew clean build --no-daemon ${{ inputs.run-tests && '' || '-x test' }}
+      - name: Build (with tests)
+        if: ${{ inputs['run-tests'] == true }}
+        run: ./gradlew clean build --no-daemon
+
+      - name: Build (skip tests)
+        if: ${{ inputs['run-tests'] != true }}
+        run: ./gradlew clean build --no-daemon -x test


### PR DESCRIPTION
<현재 상황>
CI: Build (with tests) / `./gradlew clean build --no-daemon -x test`
CD: Build (skip tests) / `./gradlew clean build --no-daemon -x test`

-x test 만 분기 처리가 안되는 상황..

<추측>
- 하이픈 키를 점 표기(inputs.run-tests)로 읽을 때 컨텍스트마다 진리값/문자열로 달리 강제변환되어 좌우 분기가 불일치할 수 있다.
- 대괄호 표기로 테스트